### PR TITLE
Terraform DEMO: Adding SQS queue

### DIFF
--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -1,0 +1,9 @@
+resource "aws_sqs_queue" "terraform_queue" {
+  name                      = "terraform-example-queue"
+  delay_seconds             = 90
+  max_message_size          = 2048
+  message_retention_seconds = 86400
+  receive_wait_time_seconds = 10
+
+  tags = local.common_tags
+}


### PR DESCRIPTION
Adding an SQS queue in order to handle visitor metrics. 

```hcl
  # aws_sqs_queue.terraform_queue will be created
  + resource "aws_sqs_queue" "terraform_queue" {
      + arn                               = (known after apply)
      + content_based_deduplication       = false
      + delay_seconds                     = 90
      + fifo_queue                        = false
      + id                                = (known after apply)
      + kms_data_key_reuse_period_seconds = (known after apply)
      + max_message_size                  = 2048
      + message_retention_seconds         = 86400
      + name                              = "terraform-example-queue"
      + policy                            = (known after apply)
      + receive_wait_time_seconds         = 10
      + tags                              = {
          + "Environment"                    = "ekoparty"
          + "Name"                           = "ekoparty"
          + "kubernetes.io/cluster/ekoparty" = "shared"
          + "kubernetes.io/role/elb"         = "1"
        }
      + visibility_timeout_seconds        = 30
    }
```